### PR TITLE
fixed deprecated varchar(max) operation for sqlalchemy

### DIFF
--- a/etlcore/DB/DB.py
+++ b/etlcore/DB/DB.py
@@ -24,7 +24,13 @@ class DB():
     def load_to_staging(self, df: pd.DataFrame, schema: str, table_name: str, dtype_dict: dict) -> bool:
         try:
             chunksize = 2100 // len(df.columns) #calculating chunksize
-            df.to_sql(name = f"RAW_{table_name}", dtype= dtype_dict, con = self.engine, schema = schema, if_exists = "replace", index=False, chunksize=chunksize)
+            df.to_sql(name = f"RAW_{table_name}", 
+                      dtype= dtype_dict, 
+                      con = self.engine, 
+                      schema = schema, 
+                      if_exists = "replace", 
+                      index=False, 
+                      chunksize=chunksize)
             return True
         except Exception as e:
             return f"insert failed {str(e)}"

--- a/etlcore/DataUtils/DataUtils.py
+++ b/etlcore/DataUtils/DataUtils.py
@@ -72,11 +72,14 @@ class DataUtils():
                     case "smalldatetime":
                         table_dtypes.update({row.COLUMN_NAME: SMALLDATETIME()})
                     case "char":
-                        table_dtypes.update({row.COLUMN_NAME: CHAR(row.CHARACTER_MAXIMUM_LENGTH)})
+                        table_dtypes.update({row.COLUMN_NAME: CHAR(int(row.CHARACTER_MAXIMUM_LENGTH))})
                     case "text":
                         table_dtypes.update({row.COLUMN_NAME: String()})
                     case "varchar":
-                        table_dtypes.update({row.COLUMN_NAME: String(row.CHARACTER_MAXIMUM_LENGTH)})
+                        if row.CHARACTER_MAXIMUM_LENGTH == 'MAX':
+                            table_dtypes.update({row.COLUMN_NAME: String(None)})
+                        else:
+                            table_dtypes.update({row.COLUMN_NAME: String(int(row.CHARACTER_MAXIMUM_LENGTH))})
                     case "uniqueidentifier":
                         table_dtypes.update({row.COLUMN_NAME: UNIQUEIDENTIFIER()})
             del df


### PR DESCRIPTION
newer version of sqlalchemy did not support "max" function, had to switch to "none"