### PR TITLE
ensure str type in dataframe

### DIFF
--- a/etlcore/DataUtils/DataUtils.py
+++ b/etlcore/DataUtils/DataUtils.py
@@ -114,12 +114,7 @@ class DataUtils():
                     # NOOP
                     pass
                 elif type(dtypes[c] in [type(String())]):
-                    col_length = max(df.loc[:, c].astype(str).apply(len))
-                    if dtypes[c].length is None and col_length < 8000:
-                        dtypes[c] = String(col_length)
-                        print(
-                            "Updated column {} from String() to String({})".format(c, col_length)
-                        ) 
+                    df.loc[:, c] = df.loc[:, c].astype("str")
             return df          
         except Exception as e:
             return f"unable to convert column types {str(e)}"


### PR DESCRIPTION
Received error that I'm fixing:
(\'String data, right truncation: length 86 buffer 20\', \'HY000\')

This issue is occuring because the function incorrectly initializes the max length value of the string object.
As long as the table definition is correct, this shouldn't have to be checked.

Updated to just ensure the dataframe cells are the correct type - strings.