### PR TITLE
bug fix for converting datetimes

### DIFF
--- a/etlcore/DataUtils/DataUtils.py
+++ b/etlcore/DataUtils/DataUtils.py
@@ -105,7 +105,7 @@ class DataUtils():
                     type(DATETIME2()),
                     type(SMALLDATETIME()),
                 ]:
-                    df.loc[:, c] = pd.to_datetime(df.loc[:, c], format='mixed')
+                    df.loc[:, c] = pd.to_datetime(df.loc[:, c], format="mixed")
                 elif type(dtypes[c]) in [type(Boolean())]:
                     # Handle Yes/No/Null
                     df.loc[:, c] = df.loc[:, c].map(bool_type, na_action="ignore")

--- a/etlcore/DataUtils/DataUtils.py
+++ b/etlcore/DataUtils/DataUtils.py
@@ -105,7 +105,7 @@ class DataUtils():
                     type(DATETIME2()),
                     type(SMALLDATETIME()),
                 ]:
-                    df.loc[:, c] = pd.to_datetime(df.loc[:, c], errors="coerce")
+                    df.loc[:, c] = pd.to_datetime(df.loc[:, c], format='mixed')
                 elif type(dtypes[c]) in [type(Boolean())]:
                     # Handle Yes/No/Null
                     df.loc[:, c] = df.loc[:, c].map(bool_type, na_action="ignore")


### PR DESCRIPTION
Using errors='coerce' from before was causing some data to get lost in translate as we converted to datetimes. The returned error was the following:

'unable to convert column types time data "2018-10-16 09:14:18" doesn\'t match format "%Y-%m-%d %H:%M:%S.%f", at position 75. You might want to try:\n    - passing `format` if your strings have a consistent format;\n    - passing `format=\'ISO8601\'` if your strings are all ISO8601 but not necessarily in exactly the same format;\n    - passing `format=\'mixed\'`, and the format will be inferred for each element individually. You might want to use `dayfirst` alongside this.'

I removed errors param and added format param. I tested with AssessmentStatus, Assessment and BilledExclude.