### PR TITLE
pinned msal to 1.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 "jsonpatch==1.33",
 "jsonschema==4.23.0",
 "kubernetes==29.0.0",
+"msal==1.32.0",
 "orjson==3.10.7",
 "packaging==24.1",
 "pathspec==0.12.1",


### PR DESCRIPTION
pinned msal to 1.32.0, newer versions were breaking access to keyvault